### PR TITLE
RFH(elp): Fixed the super type of AFAbstractArray

### DIFF
--- a/src/ArrayFire.jl
+++ b/src/ArrayFire.jl
@@ -4,7 +4,7 @@ export AFArray
 
 include("config.jl")
 
-abstract AFAbstractArray{T,N} <: AbstractArray{T,4}
+abstract AFAbstractArray{T,N} <: AbstractArray{T,N}
 
 type AFArray{T,N} <: AFAbstractArray{T,N}
     ptr::Ptr{Void}

--- a/src/cxx/ArrayFire.jl
+++ b/src/cxx/ArrayFire.jl
@@ -32,7 +32,7 @@ function init_library()
     end
     if !haskey(ENV, "AFPATH")
        addHeaderDir("/usr/local/include/"; kind = C_System)
-    else 
+    else
         addHeaderDir(ENV["APATH"]; kind = C_System)
     end
 end
@@ -119,7 +119,7 @@ function af_promote{T,S}(::Type{T},::Type{S})
     end
 end
 
-abstract AFAbstractArray{T,N} <: AbstractArray{T,4}
+abstract AFAbstractArray{T,N} <: AbstractArray{T,N}
 
 immutable AFArray{T,N} <: AFAbstractArray{T,N}
     array::vcpp"af::array"
@@ -266,7 +266,7 @@ const tis = to_af_idx
 IS = Union{Real,Range,Colon,rcpp"af::seq"}
 
 #ArrayFire needs to index with Int32s or Float32s. Also, array_proxy wrap for indexing with arrays crashes currently.
-function _getindex(x::AFAbstractArray,y::AFAbstractArray)  
+function _getindex(x::AFAbstractArray,y::AFAbstractArray)
     idx = y - 1
     out = AFArray()
     icxx"$out = $x($idx);"
@@ -320,9 +320,9 @@ function setindex!{T}(x::AFAbstractArray{T}, val, idxs...)
     icxx"$proxy = $val;"
 end
 
-# Avoid crash when referencing with boolean arrays with all falses 
+# Avoid crash when referencing with boolean arrays with all falses
 function setindex!(x::AFAbstractArray, val, b::AFAbstractArray{Bool})
-    if any(b) 
+    if any(b)
         icxx"$x($b) = $val;"
     else
         return val
@@ -371,7 +371,7 @@ getDevice() = af_getDevice()
 
 #Storing and Loading Arrays
 save(a::AFAbstractArray, path::AbstractString, key::AbstractString) = af_saveArray(key, a, path)
-function load(path::AbstractString, key::AbstractString) 
+function load(path::AbstractString, key::AbstractString)
     out = af_readArray(path, key)
     AFArray{backend_eltype(out)}(out)
 end
@@ -380,7 +380,7 @@ macro gpu(ex...)
     ex = ex[1]
     top = ex.args[1]
     bottom = ex.args[2]
-    iterator = top.args[1]       
+    iterator = top.args[1]
     start = :($(top.args[2]).start)
     step = :(step($(top.args[2])))
     stop = :($(top.args[2]).stop)
@@ -388,7 +388,7 @@ macro gpu(ex...)
     body = Expr(:->,:i,Expr(:block, x, :nothing))
     esc(Expr(:let, quote icxx"""
                     gfor (af::seq i, $start - 1, $stop - 1, $step)
-                    {   
+                    {
                         $body(i);
                     }
                     """

--- a/src/math.jl
+++ b/src/math.jl
@@ -5,7 +5,7 @@ import Base: &, |, $, .>, .>=, .<, .<=, !, .==, .!=, ^, .^, /, ./
 
 export sigmoid
 
-for (op,fn) in ((:+,:af_add), (:.+,:af_add), (:-,:af_sub), (:.-,:af_sub), (:.*,:af_mul), 
+for (op,fn) in ((:+,:af_add), (:.+,:af_add), (:-,:af_sub), (:.-,:af_sub), (:.*,:af_mul),
                 (:./,:af_div), (:%, :af_mod), (:.%, :af_mod), (:<<, :af_bitshiftl),
                 (:.<<, :af_bitshiftl),(:>>, :af_bitshiftr), (:.>>, :af_bitshiftr),
                 (:^, :af_pow), (:.^, :af_pow ))
@@ -13,7 +13,7 @@ for (op,fn) in ((:+,:af_add), (:.+,:af_add), (:-,:af_sub), (:.-,:af_sub), (:.*,:
     @eval function Base.($(quot(op))){T,S}(a::AFArray{T}, b::AFArray{S}; batched = true)
         ptr = new_ptr()
         eval($(quot(fn)))(ptr, a, b, batched)
-        AFArray{af_promote(T,S)}(ptr[]) 
+        AFArray{af_promote(T,S)}(ptr[])
     end
 
 end
@@ -26,10 +26,12 @@ Base.(:-)(v::Bool, a::AFArray{Bool}) = -(a,v)
 
 ^{T<:Real}(a::AFArray{T}, v::Integer) = ^(a, Real(v))
 ^{T<:Real}(a::AFArray{Complex{T}}, v::Integer) = ^(a, Real(v))
-.^{T<:Real}(v::Irrational{:e}, a::AFArray{T}) = ^(Real(e), a) 
-.^{T<:Real}(v::Irrational{:e}, a::AFArray{Complex{T}}) = ^(Real(e), a) 
+.^{T<:Real}(v::Irrational{:e}, a::AFArray{T}) = ^(Real(e), a)
+.^{T<:Real}(v::Irrational{:e}, a::AFArray{Complex{T}}) = ^(Real(e), a)
+^{T<:Real}(v::Irrational{:e}, a::AFArray{T,2}) = ^(Real(e), a)
+^{T<:Real}(v::Irrational{:e}, a::AFArray{Complex{T},2}) = ^(Real(e), a)
 
-for (op,fn) in ((:+, :af_add), (:.+, :af_add), (:-, :af_sub), (:.-, :af_sub), (:*, :af_mul), 
+for (op,fn) in ((:+, :af_add), (:.+, :af_add), (:-, :af_sub), (:.-, :af_sub), (:*, :af_mul),
                 (:.*, :af_mul), (:./, :af_div), (:%, :af_mod), (:.%, :af_mod),
                 (:^, :af_pow), (:.^, :af_pow))
 
@@ -37,69 +39,69 @@ for (op,fn) in ((:+, :af_add), (:.+, :af_add), (:-, :af_sub), (:.-, :af_sub), (:
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
         eval($(quot(fn)))(ptr, a, b, true)
-        AFArray{af_promote(T,S)}(ptr[]) 
+        AFArray{af_promote(T,S)}(ptr[])
     end
 
     @eval function Base.($(quot(op))){T<:Real,S<:Real}(a::AFArray{T}, v::Complex{S})
         b = constant(Complex{af_promote(T,S)}(v), size(a)...)
         ptr = new_ptr()
         eval($(quot(fn)))(ptr, a, b, true)
-        AFArray{Complex{af_promote(T,S)}}(ptr[]) 
+        AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @eval function Base.($(quot(op))){T<:Real,S<:Real}(v::S, a::AFArray{T})
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
         eval($(quot(fn)))(ptr, b, a, true)
-        AFArray{af_promote(T,S)}(ptr[]) 
+        AFArray{af_promote(T,S)}(ptr[])
     end
 
     @eval function Base.($(quot(op))){T<:Real,S<:Real}(v::Complex{S}, a::AFArray{T})
         b = constant(Complex{af_promote(T,S)}(v), size(a)...)
         ptr = new_ptr()
         eval($(quot(fn)))(ptr, b, a, true)
-        AFArray{Complex{af_promote(T,S)}}(ptr[]) 
+        AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @eval function Base.($(quot(op))){T<:Real,S<:Real}(a::AFArray{Complex{T}}, v::S)
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
         eval($(quot(fn)))(ptr, a, b, true)
-        AFArray{Complex{af_promote(T,S)}}(ptr[]) 
+        AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @eval function Base.($(quot(op))){T<:Real,S<:Real}(a::AFArray{Complex{T}}, v::Complex{S})
         b = constant(Complex{af_promote(T,S)}(v), size(a)...)
         ptr = new_ptr()
         eval($(quot(fn)))(ptr, a, b, true)
-        AFArray{Complex{af_promote(T,S)}}(ptr[]) 
+        AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @eval function Base.($(quot(op))){T<:Real,S<:Real}(v::S, a::AFArray{Complex{T}})
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
         eval($(quot(fn)))(ptr, b, a, true)
-        AFArray{Complex{af_promote(T,S)}}(ptr[]) 
+        AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @eval function Base.($(quot(op))){T<:Real,S<:Real}(v::Complex{S}, a::AFArray{Complex{T}})
         b = constant(Complex{af_promote(T,S)}(v), size(a)...)
         ptr = new_ptr()
         eval($(quot(fn)))(ptr, b, a, true)
-        AFArray{Complex{af_promote(T,S)}}(ptr[]) 
+        AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 end
 /{T,S<:Real}(a::AFArray{T}, v::S) = ./(a, v)
 /{T,S<:Real}(a::AFArray{T}, v::Complex{S}) = ./(a, v)
 
-for (op,fn) in ((:sin, :af_sin), (:cos, :af_cos), (:tan, :af_tan), (:asin, :af_asin), 
+for (op,fn) in ((:sin, :af_sin), (:cos, :af_cos), (:tan, :af_tan), (:asin, :af_asin),
                 (:acos, :af_acos), (:atan, :af_atan), (:sinh, :af_sinh), (:cosh, :af_cosh),
                 (:tanh, :af_tanh), (:asinh, :af_asinh), (:acosh, :af_acosh), (:atanh, :af_atanh),
                 (:cbrt, :af_cbrt), (:erf, :af_erf), (:erfc, :af_erfc), (:exp, :af_exp),
                 (:expm1, :af_expm1), (:factorial, :af_factorial), (:lgamma, :af_lgamma),
                 (:log, :af_log), (:log10, :af_log10), (:log1p, :af_log1p), (:sqrt, :af_sqrt),
                 (:gamma, :af_tgamma), (:log2, :af_log2))
-    @eval function Base.($(quot(op)))(a::AFArray) 
+    @eval function Base.($(quot(op)))(a::AFArray)
         out = new_ptr()
         eval($(quot(fn)))(out, a)
         AFArray{backend_eltype(out[])}(out[])
@@ -137,13 +139,13 @@ function real{T<:Real}(a::AFArray{Complex{T}})
     out = new_ptr()
     af_real(out, a)
     AFArray{T}(out[])
-end 
+end
 
 function real{T<:Real}(a::AFArray{T})
     out = new_ptr()
     af_real(out, a)
     AFArray{T}(out[])
-end 
+end
 
 function imag{T}(a::AFArray{T})
     out = new_ptr()
@@ -181,7 +183,7 @@ end
 
 for (op,fn) in ((:abs, :af_abs), (:arg, :af_arg),
                 (:ceil, :af_ceil), (:sign, :af_sign),
-                (:floor, :af_floor), (:round, :af_round), 
+                (:floor, :af_floor), (:round, :af_round),
                 (:trunc, :af_trunc))
 
     @eval function ($op){T}(a::AFArray{T})
@@ -201,7 +203,7 @@ end
 # Logical Operations
 
 for (op,fn) in ((:&, :af_bitand),(:|, :af_bitor), (:$, :af_bitxor),
-                (:.==, :af_eq), (:.!=, :af_neq), (:.>, :af_gt), 
+                (:.==, :af_eq), (:.!=, :af_neq), (:.>, :af_gt),
                 (:.>=, :af_ge), (:.<, :af_lt), (:.<=, :af_le),
                 (:.!=, :af_neq))
 
@@ -210,7 +212,7 @@ for (op,fn) in ((:&, :af_bitand),(:|, :af_bitor), (:$, :af_bitxor),
         eval($fn)(out, a, b, batched)
         AFArray{backend_eltype(out[])}(out[])
     end
-    
+
     @eval function ($op)(a::AFArray, b::Real; batched = true)
         out = new_ptr()
         tmp = constant(b, size(a))
@@ -224,5 +226,5 @@ end
 function !{T}(a::AFArray{T})
     out = new_ptr()
     af_not(out, a)
-    AFArray{T}(out[]) 
+    AFArray{T}(out[])
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -12,11 +12,11 @@ end
 new_ptr() = Base.RefValue{Ptr{Void}}(C_NULL)
 
 sizeof{T}(a::AFArray{T}) = elsize(a) * length(a)
-    
+
 function convert{T,N}(::Type{Array{T,N}}, x::AFAbstractArray{T,N})
     ret = Array(UInt8, sizeof(x))
-    err = ccall((:af_get_data_ptr, af_lib), 
-                Cint, (Ptr{T}, Ptr{Ptr{Void}}), 
+    err = ccall((:af_get_data_ptr, af_lib),
+                Cint, (Ptr{T}, Ptr{Ptr{Void}}),
                 pointer(ret), x.ptr)
     err == 0 || throwAFerror(err)
     #af_get_data_ptr!(ret, x, T)
@@ -31,7 +31,7 @@ function size(a::AFArray)
     dim1 = Base.RefValue{Cuint}(0)
     dim2 = Base.RefValue{Cuint}(0)
     dim3 = Base.RefValue{Cuint}(0)
-    dim4 =Base.RefValue{Cuint}(0)   
+    dim4 =Base.RefValue{Cuint}(0)
     af_get_dims!(dim1, dim2, dim3, dim4, a)
     n = ndims(a)
     dim4_to_dims(Dim4(dim1[], dim2[], dim3[], dim4[]), n)
@@ -59,10 +59,10 @@ function get_all_dims(a::Array)
     end
     dims
 end
-        
+
 function ndims(a::AFArray)
     n = Base.RefValue{Cuint}(0)
-    af_get_numdims!(n, a.ptr) 
+    af_get_numdims!(n, a.ptr)
     Int(n[])
 end
 
@@ -70,7 +70,7 @@ function ndims(ptr::Ptr{Void})
     n = Base.RefValue{Cuint}(0)
     af_get_numdims!(n, ptr)
     Int(n[])
-end 
+end
 
 call{T}(::Type{AFArray{T}}, ptr::Ptr{Void}) = AFArray{T, ndims(ptr)}(ptr)
 
@@ -89,7 +89,7 @@ end
 
 backend_eltype(a::AFArray) = backend_eltype(a.ptr)
 
-function AFInfo() 
+function AFInfo()
     af_info()
     nothing
 end
@@ -184,7 +184,7 @@ function circshift{T}(a::AFArray{T}, shifts::Vector{Int})
     out = new_ptr()
     af_shift(out, a, shifts...)
     AFArray{T}(out[])
-end 
+end
 
 function make4Dshift!(s::Vector{Int})
     l = length(s)


### PR DESCRIPTION
However, pasting:
```
julia> ad = AFArray(a);

julia> ld, ud, pd = lu(ad);
```
into the REPL makes a very long show of `[[[[[[...` and then errors with:
```
 in show_vector at show.jl:1326
 in show_vector at show.jl:1326
 in show at show.jl:1330
 in show_delim_array at show.jl:197
```
So somethings amiss there but I'm generally confused with `show`, so a pointer would be appreciated.