### PR TITLE
Fixed types for wrapped function reporting device memory info

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -227,10 +227,10 @@ function getDataRefCount(a::AFArray)
 end
 
 function deviceMemInfo()
-    alloc_bytes = Base.Ref{Cint}(0)
-    alloc_buffers = Base.Ref{Cint}(0)
-    lock_bytes = Base.Ref{Cint}(0)
-    lock_buffers = Base.Ref{Cint}(0)
+    alloc_bytes = Base.Ref{Csize_t}(0)
+    alloc_buffers = Base.Ref{Csize_t}(0)
+    lock_bytes = Base.Ref{Csize_t}(0)
+    lock_buffers = Base.Ref{Csize_t}(0)
     af_device_mem_info(alloc_bytes, alloc_buffers, lock_bytes, lock_buffers)
     Int(alloc_bytes[]), Int(alloc_buffers[]), Int(lock_bytes[]), Int(lock_buffers[])
 end

--- a/src/wrap.jl
+++ b/src/wrap.jl
@@ -1263,7 +1263,7 @@ end
 
 function af_device_mem_info(alloc_bytes::Base.Ref, alloc_buffers::Base.Ref, lock_bytes::Base.Ref, lock_buffers::Base.Ref)
     err = ccall((:af_device_mem_info, af_lib), Cint,
-                (Ptr{Cint},Ptr{Cint},Ptr{Cint},Ptr{Cint}),
+                (Ptr{Csize_t},Ptr{Csize_t},Ptr{Csize_t},Ptr{Csize_t}),
                 alloc_bytes, alloc_buffers, lock_bytes, lock_buffers)
     err == 0 || throwAFerror(err)
 end


### PR DESCRIPTION
Hi the deviceMemInfo() was reporting garbage on the CUDA backend for me.  

Looking into the code the pointers being passed into af_device_mem_info were int32s (julia's Cint) as opposed to (unsigned) size_ts (julia's Csize_t).  On my system size_t -> uint64, causing the pointers and data to become mangled and incorrect.

I've checked the change with all three backends (at least on my system) to verify that it works in all cases.  I believe this should make the code work correctly in general.  Thanks!