### PR TITLE
remove unnecessary uses of eval

### DIFF
--- a/src/cv.jl
+++ b/src/cv.jl
@@ -11,7 +11,7 @@ export  AFFeatures,
         harris,
         susan,
         hammingMatcher,
-        nearestNeighbour,        
+        nearestNeighbour,
         matchTemplate
 
 # Export constants
@@ -19,10 +19,10 @@ export  AFFeatures,
 export  AF_SAD,
         AF_ZSAD,
         AF_LSAD,
-        AF_ZSSD,   
-        AF_LSSD,   
-        AF_NCC,   
-        AF_ZNCC,    
+        AF_ZSSD,
+        AF_LSSD,
+        AF_NCC,
+        AF_ZNCC,
         AF_SHD
 
 # Feature Type
@@ -33,13 +33,13 @@ end
 
 # Constants
 
-AF_SAD = 0   
+AF_SAD = 0
 AF_ZSAD = 1
 AF_LSAD = 2
-AF_ZSSD = 3   
-AF_LSSD = 4   
-AF_NCC = 5   
-AF_ZNCC = 6    
+AF_ZSSD = 3
+AF_LSSD = 4
+AF_NCC = 5
+AF_ZNCC = 6
 AF_SHD = 7
 
 # Feature Descriptors
@@ -54,12 +54,12 @@ end
 
 for (op,fn) in ((:sift, :af_sift), (:gloh, :af_gloh))
 
-    @eval function ($op)(a::AFArray; n_layers = 3, constant_thr = 0.04, edge_thr = 0.04, 
-                    init_sigma = 1.6, double_input = true, intensity_scale = 0.00390625, 
+    @eval function ($op)(a::AFArray; n_layers = 3, constant_thr = 0.04, edge_thr = 0.04,
+                    init_sigma = 1.6, double_input = true, intensity_scale = 0.00390625,
                     feature_ratio = 0.05)
         feat = new_ptr()
         desc = new_ptr()
-        eval($fn)(feat, desc, a, Cuint(n_layers), contrast_thr, edge_thr, init_sigma, 
+        $(fn)(feat, desc, a, Cuint(n_layers), contrast_thr, edge_thr, init_sigma, 
                 double_input, intensity_scale, feature_ratio)
         AFFeatures(feat[]),
         AFArray{backend_eltype(desc[])}(desc[])
@@ -69,32 +69,32 @@ end
 
 # Feature Detectors
 
-function diffOfGaussians(a::AFArray, radius1::Int, radius2::Int) 
+function diffOfGaussians(a::AFArray, radius1::Int, radius2::Int)
     out = new_ptr()
     af_dog(out, a, radius1, radius)
     AFArray{backend_eltype(out[])}(out[])
 end
 
-function fast(a::AFArray; thr = 20., arc_length = 9, non_max = true, 
+function fast(a::AFArray; thr = 20., arc_length = 9, non_max = true,
                 feature_ratio = 0.05, edge = 3)
     out = new_ptr()
     af_fast(out, a, thr, Cuint(arc_length), non_max, feature_ratio, Cuint(edge))
     AFFeatures(out[])
-end 
+end
 
-function harris(a::AFArray; max_corners = 500, min_response = 1e-5, 
+function harris(a::AFArray; max_corners = 500, min_response = 1e-5,
                 sigma = 1., block_size = 0, k_thr = 0.04)
     out = new_ptr()
     af_harris(out, a, Cuint(max_corners), min_response, sigma, Cuint(block_size), k_thr)
     AFFeatures(out[])
-end 
+end
 
-function susan(a::AFArray; radius = 3, diff_thr = 32.0, 
+function susan(a::AFArray; radius = 3, diff_thr = 32.0,
                 geom_thr = 10.0, feature_ratio = 0.05, edge = 3)
     out = new_ptr()
     af_susan(out, a, Cuint(radius), diff_thr, geom_thr, feature_ratio, Cuint(edge))
     AFFeatures(out[])
-end 
+end
 
 # Feature Matchers
 
@@ -106,7 +106,7 @@ function hammingMatcher(a::AFArray, train::AFArray; dist_dim = 0, n_dist = 1)
     AFArray{backend_eltype(dist[])}(dist[])
 end
 
-function nearestNeighbour(a::AFArray, train::AFArray; dist_dim = 9, 
+function nearestNeighbour(a::AFArray, train::AFArray; dist_dim = 9,
                             n_dist = 1, dist_type = AF_SSD)
     idx = new_ptr()
     dist = new_ptr()

--- a/src/image.jl
+++ b/src/image.jl
@@ -264,7 +264,7 @@ for (op, fn) in ((:dilate, :af_dilate), (:dilate3d, :af_dilate3d),
 
     @eval function ($op)(a::AFArray, mask::AFArray)
         out = new_ptr()
-        eval($fn)(out, a, mask)
+        $(fn)(out, a, mask)
         AFArray{backend_eltype(out[])}(out[])
     end
 

--- a/src/math.jl
+++ b/src/math.jl
@@ -3,9 +3,9 @@ using Base.Meta
 import Base: complex, conj, real, imag, max, min, abs, round, sign, floor, hypot
 import Base: &, |, $, .>, .>=, .<, .<=, !, .==, .!=, ^, .^, /, ./
 import Base: +, .+, -, .-, *, .*, /, ./, %, .%, <<, .<<, >>, .>>, ^, .^
-import Base: sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, cbrt, erf, erfc, 
+import Base: sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, cbrt, erf, erfc,
              exp, expm1, factorial, lgamma, log, log10, log1p, sqrt, gamma, log2,
-             atan2 
+             atan2
 
 export sigmoid
 
@@ -16,7 +16,7 @@ for (op,fn) in ((:+,:af_add), (:.+,:af_add), (:-,:af_sub), (:.-,:af_sub), (:.*,:
 
     @compat @eval function $op{T,S}(a::AFArray{T}, b::AFArray{S}; batched = true)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, a, b, batched)
+        $(fn)(ptr, a, b, batched)
         AFArray{af_promote(T,S)}(ptr[])
     end
 
@@ -40,56 +40,56 @@ for (op,fn) in ((:+, :af_add), (:.+, :af_add), (:-, :af_sub), (:.-, :af_sub), (:
     @compat @eval function $op{T<:Real,S<:Real}(a::AFArray{T}, v::S)
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, a, b, true)
+        $(fn)(ptr, a, b, true)
         AFArray{af_promote(T,S)}(ptr[])
     end
 
     @compat @eval function $op{T<:Real,S<:Real}(a::AFArray{T}, v::Complex{S})
         b = constant(Complex{af_promote(T,S)}(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, a, b, true)
+        $(fn)(ptr, a, b, true)
         AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @compat @eval function $op{T<:Real,S<:Real}(v::S, a::AFArray{T})
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, b, a, true)
+        $(fn)(ptr, b, a, true)
         AFArray{af_promote(T,S)}(ptr[])
     end
 
     @compat @eval function $op{T<:Real,S<:Real}(v::Complex{S}, a::AFArray{T})
         b = constant(Complex{af_promote(T,S)}(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, b, a, true)
+        $(fn)(ptr, b, a, true)
         AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @compat @eval function $op{T<:Real,S<:Real}(a::AFArray{Complex{T}}, v::S)
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, a, b, true)
+        $(fn)(ptr, a, b, true)
         AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @compat @eval function $op{T<:Real,S<:Real}(a::AFArray{Complex{T}}, v::Complex{S})
         b = constant(Complex{af_promote(T,S)}(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, a, b, true)
+        $(fn)(ptr, a, b, true)
         AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @compat @eval function $op{T<:Real,S<:Real}(v::S, a::AFArray{Complex{T}})
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, b, a, true)
+        $(fn)(ptr, b, a, true)
         AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 
     @compat @eval function $op{T<:Real,S<:Real}(v::Complex{S}, a::AFArray{Complex{T}})
         b = constant(Complex{af_promote(T,S)}(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, b, a, true)
+        $(fn)(ptr, b, a, true)
         AFArray{Complex{af_promote(T,S)}}(ptr[])
     end
 end
@@ -105,7 +105,7 @@ for (op,fn) in ((:sin, :af_sin), (:cos, :af_cos), (:tan, :af_tan), (:asin, :af_a
                 (:gamma, :af_tgamma), (:log2, :af_log2))
     @compat @eval function $op(a::AFArray)
         out = new_ptr()
-        eval($(quot(fn)))(out, a)
+        $(fn)(out, a)
         AFArray{backend_eltype(out[])}(out[])
     end
 
@@ -114,21 +114,21 @@ end
 for (op,fn) in ((:atan2, :af_atan2),)
     @eval @compat function $op{T,S}(a::AFArray{T}, b::AFArray{S}; batched = true)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, a, b, batched)
+        $(fn)(ptr, a, b, batched)
         AFArray{af_promote(T,S)}(ptr[])
     end
 
     @eval @compat function $op{T<:Real,S<:Real}(a::AFArray{T}, v::S)
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, a, b, true)
+        $(fn)(ptr, a, b, true)
         AFArray{af_promote(T,S)}(ptr[])
     end
 
     @eval @compat function $op{T<:Real,S<:Real}(v::S, a::AFArray{T})
         b = constant((af_promote(T,S))(v), size(a)...)
         ptr = new_ptr()
-        eval($(quot(fn)))(ptr, b, a, true)
+        $(fn)(ptr, b, a, true)
         AFArray{af_promote(T,S)}(ptr[])
     end
 end
@@ -189,14 +189,14 @@ for (op,fn) in ((:max, :af_maxof), (:min, :af_minof))
 
     @eval function ($op){T,S}(a::AFArray{T}, b::AFArray{S}; batched = true)
         out = new_ptr()
-        eval($fn)(out, a, b, true)
+        $(fn)(out, a, b, true)
         AFArray{af_promote(T,S)}(out[])
     end
 
     @eval function ($op){T,S<:Real}(a::AFArray{T}, b::S)
         out = new_ptr()
         tmp = constant(b, size(a))
-        eval($fn)(out, a, tmp, true)
+        $(fn)(out, a, tmp, true)
         AFArray{af_promote(T,S)}(out[])
     end
     @eval ($op){T,S<:Real}(b::S, a::AFArray{T}) = max(a, b)
@@ -204,7 +204,7 @@ for (op,fn) in ((:max, :af_maxof), (:min, :af_minof))
     @eval function ($op){T<:Complex,S<:Complex}(a::AFArray{T}, b::S)
         out = new_ptr()
         tmp = constant(b, size(a))
-        eval($fn)(out, a, tmp, true)
+        $(fn)(out, a, tmp, true)
         AFArray{af_promote(T,S)}(out[])
     end
     @eval ($op){T<:Complex,S<:Complex}(b::S, a::AFArray{T}) = max(a, b)
@@ -218,7 +218,7 @@ for (op,fn) in ((:abs, :af_abs), (:arg, :af_arg),
 
     @eval function ($op){T}(a::AFArray{T})
         out = new_ptr()
-        eval($fn)(out, a)
+        $(fn)(out, a)
         AFArray{T}(out[])
     end
 
@@ -238,14 +238,14 @@ for (op,fn) in ((:&, :af_bitand),(:|, :af_bitor), (:$, :af_bitxor),
 
     @eval function ($op)(a::AFArray, b::AFArray; batched = true)
         out = new_ptr()
-        eval($fn)(out, a, b, batched)
+        $(fn)(out, a, b, batched)
         AFArray{backend_eltype(out[])}(out[])
     end
 
     @eval function ($op)(a::AFArray, b::Real; batched = true)
         out = new_ptr()
         tmp = constant(b, size(a))
-        eval($fn)(out, a, tmp, batched)
+        $(fn)(out, a, tmp, batched)
         AFArray{backend_eltype(out[])}(out[])
     end
     @eval ($op)(b::Real, a::AFArray) = ($op)(a, b)

--- a/src/signal.jl
+++ b/src/signal.jl
@@ -1,15 +1,15 @@
-### Signal Processing 
+### Signal Processing
 
 import Base: fft, ifft, fft!, ifft!, conv, conv2
 
 # Export Methods
 
-export  fftC2R, 
-        fftR2C, 
-        conv3, 
+export  fftC2R,
+        fftR2C,
+        conv3,
         convolve,
         fir,
-        iir, 
+        iir,
         approx1,
         approx2
 
@@ -36,13 +36,13 @@ for (op, fn) in ((:fft, :af_fft), (:ifft, :af_ifft))
 
     @eval function ($op){T<:Real}(a::AFVector{T}; norm_factor = 1., dim1 = 0)
         out = new_ptr()
-        eval($fn)(out, a, norm_factor, dim1)
+        $(fn)(out, a, norm_factor, dim1)
         AFArray{Complex{T}}(out[])
     end
 
     @eval function ($op){T<:Complex}(a::AFVector{T}; norm_factor = 1., dim1 = 0)
         out = new_ptr()
-        eval($fn)(out, a, norm_factor, dim1)
+        $(fn)(out, a, norm_factor, dim1)
         AFArray{T}(out[])
     end
 
@@ -52,13 +52,13 @@ for (op, fn) in ((:fft, :af_fft2), (:ifft, :af_ifft2))
 
     @eval function ($op){T<:Real}(a::AFMatrix{T}; norm_factor = 1., dim1 = 0, dim2 = 0)
         out = new_ptr()
-        eval($fn)(out, a, norm_factor, dim1, dim2)
+        $(fn)(out, a, norm_factor, dim1, dim2)
         AFArray{Complex{T}}(out[])
     end
 
     @eval function ($op){T<:Complex}(a::AFMatrix{T}; norm_factor = 1., dim1 = 0, dim2 = 0)
         out = new_ptr()
-        eval($fn)(out, a, norm_factor, dim1, dim2)
+        $(fn)(out, a, norm_factor, dim1, dim2)
         AFArray{T}(out[])
     end
 
@@ -68,13 +68,13 @@ for (op, fn) in ((:fft, :af_fft3), (:ifft, :af_ifft3))
 
     @eval function ($op){T<:Real}(a::AFArray{T,3}; norm_factor = 1., dim1 = 0, dim2 = 0, dim3 = 0)
         out = new_ptr()
-        eval($fn)(out, a, norm_factor, dim1, dim2, dim3)
+        $(fn)(out, a, norm_factor, dim1, dim2, dim3)
         AFArray{Complex{T}}(out[])
     end
 
     @eval function ($op){T<:Complex}(a::AFArray{T,3}; norm_factor = 1., dim1 = 0, dim2 = 0, dim3 = 0)
         out = new_ptr()
-        eval($fn)(out, a, norm_factor, dim1, dim2, dim3)
+        $(fn)(out, a, norm_factor, dim1, dim2, dim3)
         AFArray{T}(out[])
     end
 
@@ -85,7 +85,7 @@ for (op, fn) in ((:fft, :af_fft), (:ifft, :af_ifft))
     @eval function ($op){T<:Real}(a::AFArray{T}, dim::Integer)
         out = new_ptr()
         if dim == 1
-            eval($fn)(out, a, 1., 0)
+            $(fn)(out, a, 1., 0)
         else
             throw("This dimension is not currently supported")
         end
@@ -95,7 +95,7 @@ for (op, fn) in ((:fft, :af_fft), (:ifft, :af_ifft))
     @eval function ($op){T<:Complex}(a::AFArray{T}, dim::Integer)
         out = new_ptr()
         if dim == 1
-            eval($fn)(out, a, 1., 0)
+            $(fn)(out, a, 1., 0)
         else
             throw("This dimension is not currently supported")
         end
@@ -107,12 +107,12 @@ end
 for (op, fn) in ((:fft!, :af_fft_inplace), (:ifft!, :af_ifft_inplace))
 
     @eval function ($op){T<:Real}(a::AFVector{T}; norm_factor = 1.)
-        eval($fn)(a, norm_factor)
+        $(fn)(a, norm_factor)
         a
     end
 
     @eval function ($op){T<:Complex}(a::AFVector{T}; norm_factor = 1.)
-        eval($fn)(a, norm_factor)
+        $(fn)(a, norm_factor)
         a
     end
 
@@ -121,12 +121,12 @@ end
 for (op, fn) in ((:fft!, :af_fft2_inplace), (:ifft!, :af_ifft2_inplace))
 
     @eval function ($op){T<:Real}(a::AFMatrix{T}, norm_factor = 1.)
-        eval($fn)(a, norm_factor)
+        $(fn)(a, norm_factor)
         a
     end
 
     @eval function ($op){T<:Complex}(a::AFMatrix{T}, norm_factor = 1.)
-        eval($fn)(a, norm_factor)
+        $(fn)(a, norm_factor)
         a
     end
 
@@ -135,12 +135,12 @@ end
 for (op, fn) in ((:fft!, :af_fft3_inplace), (:ifft!, :af_ifft3_inplace))
 
     @eval function ($op){T<:Real}(a::AFArray{T,3}, norm_factor = 1.)
-        eval($fn)(a, norm_factor)
+        $(fn)(a, norm_factor)
         a
     end
 
     @eval function ($op){T<:Complex}(a::AFArray{T,3}, norm_factor = 1.)
-        eval($fn)(a, norm_factor)
+        $(fn)(a, norm_factor)
         a
     end
 
@@ -151,7 +151,7 @@ for (arr, fn) in ((:(AFVector{Complex{T}}), :af_fft_c2r), (:(AFMatrix{Complex{T}
 
     @eval function fftC2R{T<:Real}(a::($arr); is_odd = false, norm_factor = 0.)
         out = new_ptr()
-        eval($fn)(out, a, norm_factor, is_odd)
+        $(fn)(out, a, norm_factor, is_odd)
         AFArray{T}(out[])
     end
 
@@ -162,7 +162,7 @@ function fftR2C{T}(a::AFVector{T}, pad1::Integer; norm_factor = 0.)
     af_fft_r2c(out, a, norm_factor, pad1)
     AFArray{Complex{T}}(out[])
 end
-     
+
 function fftR2C{T}(a::AFMatrix{T}, pad1::Integer, pad2::Integer; norm_factor = 0.)
     out = new_ptr()
     af_fft2_r2c(out, a, norm_factor, pad1)
@@ -183,7 +183,7 @@ for (op, arr1, arr2, fn) in ((:conv, :(sig::AFVector{T}), :(fil::AFVector{S}), :
 
     @eval function ($op){T,S}($arr1, $arr2; mode = AF_CONV_EXPAND)
         out = new_ptr()
-        eval($fn)(out, sig, fil, mode)
+        $(fn)(out, sig, fil, mode)
         AFArray{af_promote(T,S)}(out[])
     end
 
@@ -195,7 +195,7 @@ for (arr1, arr2, fn) in ((:(sig::AFVector{T}), :(fil::AFVector{S}), :af_convolve
 
     @eval function convolve{T,S}($arr1, $arr2; mode = AF_CONV_EXPAND, domain = AF_CONV_AUTO)
         out = new_ptr()
-        eval($fn)(out, sig, fil, mode, domain)
+        $(fn)(out, sig, fil, mode, domain)
         AFArray{af_promote(T,S)}(out[])
     end
 

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -10,44 +10,44 @@ for (op, fn) in ((:mean, :af_mean_all), (:median, :af_median_all),
     @eval function ($op){T<:Real}(a::AFArray{T})
         real = Base.Ref{Cdouble}(0)
         imag = Base.Ref{Cdouble}(0)
-        eval($fn)(real, imag, a)
+        $(fn)(real, imag, a)
         T(real[])
-    end 
+    end
 
     @eval function ($op){T<:Complex}(a::AFArray{T})
         real = Base.Ref{Cdouble}(0)
         imag = Base.Ref{Cdouble}(0)
-        eval($fn)(real, imag, a)
+        $(fn)(real, imag, a)
         complex(real[], imag[])
     end
 
 end
 
-for (op, fn) in ((:meanWeighted, :af_mean_all_weighted), 
+for (op, fn) in ((:meanWeighted, :af_mean_all_weighted),
                     (:varWeighted, :af_var_all_weighted))
 
     @eval function ($op){T<:Real,S}(a::AFArray{T}, w::AFArray{S})
         real = Base.Ref{Cdouble}(0)
         imag = Base.Ref{Cdouble}(0)
-        eval($fn)(real, imag, a, w)
+        $(fn)(real, imag, a, w)
         T(real[])
-    end 
+    end
 
     @eval function ($op){T<:Complex,S}(a::AFArray{T}, w::AFArray{S})
         real = Base.Ref{Cdouble}(0)
         imag = Base.Ref{Cdouble}(0)
-        eval($fn)(real, imag, a, w)
+        $(fn)(real, imag, a, w)
         complex(real[], imag[])
     end
 
 end
 
-for (op, fn) in ((:mean, :af_mean), (:median, :af_median), 
+for (op, fn) in ((:mean, :af_mean), (:median, :af_median),
                     (:std, :af_stdev))
 
     @eval function ($op){T}(a::AFArray{T}, dim::Integer)
         out = new_ptr()
-        eval($fn)(out, a, Cuint(dim-1))
+        $(fn)(out, a, Cuint(dim-1))
         AFArray{T}(out[])
     end
 
@@ -57,7 +57,7 @@ for (op, fn) in ((:meanWeighted, :af_mean_weighted), (:varWeighted, :af_var_weig
 
     @eval function ($op){T}(a::AFArray{T}, w::AFArray{T}, dim::Integer)
         out = new_ptr()
-        eval($fn)(out, a, w, Cuint(dim-1))
+        $(fn)(out, a, w, Cuint(dim-1))
         AFArray{T}(out[])
     end
 
@@ -92,4 +92,3 @@ function corrcoef(a::AFArray, b::AFArray)
         complex(real[], imag[])
     end
 end
-    

--- a/src/vector.jl
+++ b/src/vector.jl
@@ -13,14 +13,14 @@ for (op,fn) in ((:sum, :af_sum_all), (:product, :af_product_all),
     @eval function ($op){T<:Real}(a::AFArray{T})
         real = Base.Ref{Cdouble}(0)
         imag = Base.Ref{Cdouble}(0)
-        eval($(quot(fn)))(real, imag, a)
+        $(fn)(real, imag, a)
         real[]
     end
 
     @eval function ($op){T<:Complex}(a::AFArray{T})
         real = Base.Ref{Cdouble}(0)
         imag = Base.Ref{Cdouble}(0)
-        eval($(quot(fn)))(real, imag, a)
+        $(fn)(real, imag, a)
         complex(real[], imag[])
     end
 
@@ -45,7 +45,7 @@ for (op,fn) in ((:any, :af_any_true_all),(:all, :af_all_true_all))
     @eval function ($op){T}(a::AFArray{T})
         real = Base.Ref{Cdouble}(0)
         imag = Base.Ref{Cdouble}(0)
-        eval($fn)(real, imag, a)
+        $(fn)(real, imag, a)
         Bool(real[])
     end
 
@@ -56,7 +56,7 @@ for (op,fn) in ((:any, :af_any_true), (:all, :af_all_true))
     @eval function ($op){T}(a::AFArray{T}, dim::Integer)
         dim = dim - 1
         out = new_ptr()
-        eval($fn)(out, a, dim)
+        $(fn)(out, a, dim)
         AFArray{Bool}(out[])
     end
 
@@ -68,7 +68,7 @@ for (op, fn) in ((:sum, :af_sum), (:product, :af_product),
     @eval function ($op){T}(a::AFArray{T}, dim::Integer)
         dim = dim - 1
         out = new_ptr()
-        eval($(quot(fn)))(out, a, dim)
+        $(fn)(out, a, dim)
         AFArray{T}(out[])
     end
 
@@ -161,7 +161,7 @@ for (op, fn) in ((:findmax, :af_imax_all), (:findmin, :af_imin_all))
         real = Base.Ref{Cdouble}(0)
         imag = Base.Ref{Cdouble}(0)
         idx = Base.Ref{Cuint}(0)
-        eval($fn)(real, imag, idx, a)
+        $(fn)(real, imag, idx, a)
         real[], Int(idx[]) + 1
     end
 
@@ -169,7 +169,7 @@ for (op, fn) in ((:findmax, :af_imax_all), (:findmin, :af_imin_all))
         real = Base.Ref{Cdouble}(0)
         imag = Base.Ref{Cdouble}(0)
         idx = Base.Ref{Cuint}(0)
-        eval($fn)(real, imag, idx, a)
+        $(fn)(real, imag, idx, a)
         complex(real[], imag[]), Int(idx[]) + 1
     end
 
@@ -180,7 +180,7 @@ for (op, fn) in ((:minidx, :af_imin), (:maxidx, :af_imax))
     @eval function ($op){T}(a::AFArray{T}, dim::Int)
         out = new_ptr()
         idx = new_ptr()
-        eval($fn)(out, idx, a, dim-1)
+        $(fn)(out, idx, a, dim-1)
         AFArray{T}(out[]), 
         AFArray{backend_eltype(idx[])}(idx[]) + 1
     end


### PR DESCRIPTION
This might also improve performance and type inference (not much I suppose, since these functions don't do the real work). Consider:
```Julia
@eval test(a, b) = eval($(:+))(a, b)
julia> @code_warntype test(1, 2)
Variables:
  #self#::#test
  a::Int64
  b::Int64

Body:
  begin 
      return ((Core.eval)(Core.Main,Main.+)::Any)(a::Int64,b::Int64)::Any
  end::Any
```
vs
```Julia
@eval test2(a, b) = $(:+)(a, b)
julia> @code_warntype test2(1, 2)
Variables:
  #self#::#test2
  a::Int64
  b::Int64

Body:
  begin 
      return (Base.box)(Int64,(Base.add_int)(a::Int64,b::Int64))
  end::Int64
```

Oh and my editor seemed to have removed unnecessary tabs/spaces, hope that's okay!