### PR TITLE
Fix broadcast ops

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
 julia:
   - 0.4
   - 0.5
+  - nightly
 notifications:
   email: false
 install:

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -257,3 +257,7 @@ function deviceMemInfo()
     af_device_mem_info(alloc_bytes, alloc_buffers, lock_bytes, lock_buffers)
     Int(alloc_bytes[]), Int(alloc_buffers[]), Int(lock_bytes[]), Int(lock_buffers[])
 end
+
+if VERSION >= v"0.5.0"
+    Base.broadcast{T}(f::Function, a::AFArray{T}) = f(a)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,3 +91,6 @@ let
     ind[3] = false
     @test Array(bd[ind]) == Float32[2.]
 end
+
+# Broadcast
+sin(ad) == sin.(ad)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,4 +93,6 @@ let
 end
 
 # Broadcast
-sin(ad) == sin.(ad)
+if VERSION >= v"0.5.0"
+    sin(ad) == sin.(ad)
+end


### PR DESCRIPTION
Allow dot syntax to be used for `AFArray`. Fixes #104 