### PR TITLE
Unexport `sign`, export broadcasted signbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ getActiveBackend()
 ### Arithmetic 
 * `+, -, *, /, ^, &, $, | `
 * `.+, .-, .*, ./, .>, .>=, .<, .<=, .==, .!=, `
-* `complex, conj, real, imag, max, min, abs, round, sign, floor, hypot`
+* `complex, conj, real, imag, max, min, abs, round, floor, hypot`
 * `sigmoid`
+* `signbit` (works only in vectorized form on Julia v0.5 - Ref issue #109)
 
 ### Linear Algebra
 * `chol, svd, lu, qr, lufact!, qrfact!, svdfact!`

--- a/src/ArrayFire.jl
+++ b/src/ArrayFire.jl
@@ -11,7 +11,7 @@ type AFArray{T,N} <: AbstractArray{T,N}
     ptr::Ptr{Void}
     function AFArray(ptr::Ptr{Void})
         a = new(ptr)
-        finalizer(a, x -> af_release_array(x))
+        finalizer(a, af_release_array)
         a
     end
 end

--- a/src/math.jl
+++ b/src/math.jl
@@ -1,6 +1,6 @@
 using Base.Meta
 
-import Base: complex, conj, real, imag, max, min, abs, round, sign, floor, hypot
+import Base: complex, conj, real, imag, max, min, abs, round, signbit, floor, hypot
 import Base: &, |, $, .>, .>=, .<, .<=, !, .==, .!=, ^, .^, /, ./
 import Base: +, .+, -, .-, *, .*, /, ./, %, .%, <<, .<<, >>, .>>, ^, .^
 import Base: sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, cbrt, erf, erfc,
@@ -223,6 +223,9 @@ for (op,fn) in ((:abs, :af_abs), (:arg, :af_arg),
         AFArray{T}(out[])
     end
 
+end
+if VERSION >= v"0.5.0"
+    Base.broadcast{T}(::Type{signbit}, a::AFArray{T}) = convert(AFArray{Bool}, sign(a))
 end
 
 function hypot{T}(a::AFArray{T}, b::AFArray{T}; batched = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,3 +96,13 @@ end
 if VERSION >= v"0.5.0"
     sin(ad) == sin.(ad)
 end
+
+# Sign - issue #109
+if VERSION >= v"0.5.0"
+    let 
+        a = randn(Float32, 10)
+        ad = AFArray(a)
+        @test_throws MethodError signbit(ad)
+        @test Array(signbit.(ad)) == signbit.(a)
+    end
+end


### PR DESCRIPTION
Unexports `sign` because ArrayFire's `sign` is not consistent with Julia's `sign`. But, a broadcasted version of Julia's `signbit` can be made consistent. 

Closes #109  