### PR TITLE
Force user to specify device id while using sync

### DIFF
--- a/benchmarks/benchmark.jl
+++ b/benchmarks/benchmark.jl
@@ -18,7 +18,7 @@ function matmul(a::AFArray, b::AFArray)
         r = a * b
         ArrayFire.eval(r)
     end
-    sync()
+    sync(0)
 end
 
 function fast_fourier(a::AFArray)
@@ -26,7 +26,7 @@ function fast_fourier(a::AFArray)
         r = fft(a)
         ArrayFire.eval(r)
     end
-    sync()
+    sync(0)
 end
 
 function cholesky(a::AFArray)
@@ -34,7 +34,7 @@ function cholesky(a::AFArray)
         r = chol(a)
         ArrayFire.eval(r)
     end
-    sync()
+    sync(0)
 end
 
 function random()
@@ -42,7 +42,7 @@ function random()
         r = rand(AFArray{Float32}, 5000, 5000)
         ArrayFire.eval(r)
     end
-    sync()
+    sync(0)
 end
 
 function sorting(a::AFArray)
@@ -50,7 +50,7 @@ function sorting(a::AFArray)
         r = sort(a)
         ArrayFire.eval(r)
     end
-    sync()
+    sync(0)
 end
 
 function benchmark()

--- a/benchmarks/nmf_benchmark.jl
+++ b/benchmarks/nmf_benchmark.jl
@@ -16,7 +16,7 @@ function nmf_gpu{T<:Real}(A::AFArray{T}, k::Integer, n::Int=10)
         H = H .* (W'*A) ./ ((W'*W)*H)
         W = W .* (A*H') ./ (W*(H*H'))
     end
-    sync()
+    sync(0)
     return W, H
 end
 

--- a/src/backend.jl
+++ b/src/backend.jl
@@ -84,11 +84,6 @@ function getBackendId(a::AFArray)
     backend
 end
 
-function sync()
-    b = getActiveBackendId()
-    af_sync(b)
-end
-
 function sync(b::Int)
     af_sync(b)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,3 +150,13 @@ let
         end
     end
 end
+
+# Issue #131
+let 
+    setDevice(0)
+    for i = 1:10
+        a = rand(AFArray{Float32}, 10)
+        a + 1
+    end
+    sync(0)
+end


### PR DESCRIPTION
`sync(::Int)` is new syntax.  Helps with #131 